### PR TITLE
Use CellRef for interior mutability of grid connectivity

### DIFF
--- a/grid/examples/curved_cells.rs
+++ b/grid/examples/curved_cells.rs
@@ -6,7 +6,7 @@ use solvers_traits::grid::{Geometry, Grid, Topology};
 
 fn main() {
     // Create a grid of three cells. One cell is a curved triangle, one cell is a flat triangle, the other is a curved quadrilateral
-    let mut grid = SerialGrid::new(
+    let grid = SerialGrid::new(
         Array2D::from_data(
             vec![
                 0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 1.5, 0.25, 0.0, 0.0, 0.5, 0.5, 0.5,
@@ -26,6 +26,8 @@ fn main() {
         ],
     );
 
+    let c20 = grid.topology().connectivity(2, 0);
+
     // Print information about the cells
     for i in 0..3 {
         let ti = grid.topology().index_map()[i];
@@ -44,16 +46,16 @@ fn main() {
             "cell {} is cell number {} in the toplogy and cell number {} in the geometry.",
             i, ti, gi
         );
-        let c20 = grid.topology_mut().connectivity(2, 0).row(ti).unwrap();
+        let vertices = c20.row(ti).unwrap();
         if ct == ReferenceCellType::Triangle {
             println!(
                 "The (topological) vertices of cell {} are {}, {}, and {}",
-                i, c20[0], c20[1], c20[2]
+                i, vertices[0], vertices[1], vertices[2]
             );
         } else {
             println!(
                 "The (topological) vertices of cell {} are {}, {}, {}, and {}",
-                i, c20[0], c20[1], c20[2], c20[3]
+                i, vertices[0], vertices[1], vertices[2], vertices[3]
             );
         }
         println!("The geometric points for this cell are:");
@@ -65,5 +67,5 @@ fn main() {
     }
 
     // Export the grid in gmsh format
-    export_as_gmsh(&mut grid, String::from("_examples_curved_cells.msh"));
+    export_as_gmsh(&grid, String::from("_examples_curved_cells.msh"));
 }

--- a/grid/examples/grid.rs
+++ b/grid/examples/grid.rs
@@ -4,7 +4,7 @@ use solvers_traits::grid::{Geometry, Grid, Topology};
 
 fn main() {
     // Create a regular sphere
-    let mut grid = regular_sphere(6);
+    let grid = regular_sphere(6);
 
     // Get the number of points in the geometry
     println!(
@@ -15,17 +15,18 @@ fn main() {
     // Print the number of points and cells in the topology
     println!(
         "The grid has {} points in its topology",
-        grid.topology_mut().entity_count(0)
+        grid.topology().entity_count(0)
     );
-    println!("The grid has {} cells", grid.topology_mut().entity_count(2));
+    println!("The grid has {} cells", grid.topology().entity_count(2));
 
     // Print information about the first four cells
+    let c20 = grid.topology().connectivity(2, 0);
     for i in 0..4 {
         println!("");
 
         // Print the topological vertices of a cell
         let tcell = grid.topology().index_map()[i];
-        let t_vertices = grid.topology_mut().connectivity(2, 0).row(tcell).unwrap();
+        let t_vertices = c20.row(tcell).unwrap();
         println!(
             "Triangle {} has vertices with topological numbers {}, {}, and {}",
             i, t_vertices[0], t_vertices[1], t_vertices[2]
@@ -46,16 +47,16 @@ fn main() {
     }
 
     // Save the mesh in gmsh format
-    export_as_gmsh(&mut grid, String::from("_examples_grid.msh"));
+    export_as_gmsh(&grid, String::from("_examples_grid.msh"));
 }
 
 #[test]
 fn test_surface_area() {
     for levels in 1..7 {
-        let mut grid = regular_sphere(levels);
+        let grid = regular_sphere(levels);
 
         let mut area = 0.0;
-        for i in 0..grid.topology_mut().entity_count(2) {
+        for i in 0..grid.topology().entity_count(2) {
             let v = grid.geometry().cell_vertices(i).unwrap();
             let e1 = [
                 grid.geometry().point(v[1]).unwrap()[0] - grid.geometry().point(v[0]).unwrap()[0],

--- a/grid/src/grid.rs
+++ b/grid/src/grid.rs
@@ -6,6 +6,7 @@ use solvers_tools::arrays::{AdjacencyList, Array2D};
 use solvers_traits::cell::{ReferenceCell, ReferenceCellType};
 use solvers_traits::element::FiniteElement;
 use solvers_traits::grid::{Geometry, Grid, Topology};
+use std::cell::{Ref, RefCell};
 
 /// Geometry of a serial grid
 pub struct SerialGeometry {
@@ -115,7 +116,7 @@ impl Geometry for SerialGeometry {
 /// Topology of a serial grid
 pub struct SerialTopology {
     dim: usize,
-    connectivity: Vec<Vec<AdjacencyList<usize>>>,
+    connectivity: Vec<Vec<RefCell<AdjacencyList<usize>>>>,
     index_map: Vec<usize>,
     starts: Vec<usize>,
     cell_types: Vec<ReferenceCellType>,
@@ -134,18 +135,24 @@ fn get_reference_cell(cell_type: ReferenceCellType) -> Box<dyn ReferenceCell> {
 
 impl SerialTopology {
     pub fn new(cells: &AdjacencyList<usize>, cell_types: &Vec<ReferenceCellType>) -> Self {
-        let mut c_dim0 = AdjacencyList::<usize>::new();
         let mut index_map = vec![];
         let mut vertices = vec![];
         let mut starts = vec![];
         let mut cell_types_new = vec![];
         let dim = get_reference_cell(cell_types[0]).dim();
+        let mut connectivity = vec![];
+        for i in 0..dim + 1 {
+            connectivity.push(vec![]);
+            for _j in 0..dim + 1 {
+                connectivity[i].push(RefCell::new(AdjacencyList::<usize>::new()));
+            }
+        }
         for c in cell_types {
             if dim != get_reference_cell(*c).dim() {
                 panic!("Grids with cells of mixed topological dimension not supported.");
             }
             if !cell_types_new.contains(c) {
-                starts.push(c_dim0.num_rows());
+                starts.push(connectivity[dim][0].borrow().num_rows());
                 cell_types_new.push(*c);
                 let n = get_reference_cell(*c).vertex_count();
                 for (i, cell) in cells.iter_rows().enumerate() {
@@ -159,19 +166,11 @@ impl SerialTopology {
                             }
                             row.push(vertices.iter().position(|&r| r == *v).unwrap());
                         }
-                        c_dim0.add_row(&row);
+                        connectivity[dim][0].borrow_mut().add_row(&row);
                     }
                 }
             }
         }
-        let mut connectivity = vec![];
-        for i in 0..dim + 1 {
-            connectivity.push(vec![]);
-            for _j in 0..dim + 1 {
-                connectivity[i].push(AdjacencyList::<usize>::new());
-            }
-        }
-        connectivity[dim][0] = c_dim0;
 
         Self {
             dim: dim,
@@ -207,17 +206,22 @@ impl Topology for SerialTopology {
     fn dim(&self) -> usize {
         self.dim
     }
-    fn entity_count(&mut self, dim: usize) -> usize {
-        self.create_connectivity(dim, 0);
-        self.connectivity[dim][0].num_rows()
+    fn entity_count(&self, dim: usize) -> usize {
+        self.connectivity(dim, 0).num_rows()
     }
-    fn cell(&self, index: usize) -> Option<&[usize]> {
-        self.connectivity[2][0].row(index)
+    fn cell(&self, index: usize) -> Option<Ref<[usize]>> {
+        if index < self.entity_count(self.dim) {
+            Some(Ref::map(self.connectivity(self.dim, 0), |x| unsafe {
+                x.row_unchecked(index)
+            }))
+        } else {
+            None
+        }
     }
     fn cell_type(&self, index: usize) -> Option<ReferenceCellType> {
         for (i, start) in self.starts.iter().enumerate() {
             let end = if i == self.starts.len() - 1 {
-                self.connectivity[2][0].num_rows()
+                self.connectivity[2][0].borrow().num_rows()
             } else {
                 self.starts[i + 1]
             };
@@ -227,31 +231,35 @@ impl Topology for SerialTopology {
         }
         None
     }
-    fn create_connectivity(&mut self, dim0: usize, dim1: usize) {
+    fn create_connectivity(&self, dim0: usize, dim1: usize) {
         if dim0 > self.dim() || dim1 > self.dim() {
             panic!("Dimension of connectivity should be higher than the topological dimension");
         }
 
-        if self.connectivity[dim0][dim1].num_rows() > 0 {
+        if self.connectivity[dim0][dim1].borrow().num_rows() > 0 {
             return;
         }
 
         if dim0 < dim1 {
             self.create_connectivity(dim0, 0);
             self.create_connectivity(dim1, dim0);
-            let mut data = vec![vec![]; self.connectivity[dim0][0].num_rows()];
-            for (i, row) in self.connectivity[dim1][dim0].iter_rows().enumerate() {
+            let mut data = vec![vec![]; self.connectivity[dim0][0].borrow().num_rows()];
+            for (i, row) in self.connectivity[dim1][dim0]
+                .borrow()
+                .iter_rows()
+                .enumerate()
+            {
                 for v in row {
                     data[*v].push(i);
                 }
             }
             for row in data {
-                self.connectivity[dim0][dim1].add_row(&row);
+                self.connectivity[dim0][dim1].borrow_mut().add_row(&row);
             }
         } else if dim0 == dim1 {
             if dim0 == 0 {
                 let mut nvertices = 0;
-                let cells = &self.connectivity[self.dim()][0];
+                let cells = &self.connectivity[self.dim()][0].borrow();
                 for cell in cells.iter_rows() {
                     for j in cell {
                         if *j >= nvertices {
@@ -260,17 +268,16 @@ impl Topology for SerialTopology {
                     }
                 }
                 for i in 0..nvertices {
-                    self.connectivity[0][0].add_row(&[i]);
+                    self.connectivity[0][0].borrow_mut().add_row(&[i]);
                 }
             } else {
                 self.create_connectivity(dim0, 0);
-                for i in 0..self.connectivity[dim0][0].num_rows() {
-                    self.connectivity[dim0][dim0].add_row(&[i]);
+                for i in 0..self.connectivity[dim0][0].borrow().num_rows() {
+                    self.connectivity[dim0][dim0].borrow_mut().add_row(&[i]);
                 }
             }
         } else if dim1 == 0 {
-            let cells = &self.connectivity[self.dim()][0];
-            let mut data = AdjacencyList::<usize>::new();
+            let cells = &self.connectivity[self.dim()][0].borrow();
             for (i, cell_type) in self.cell_types.iter().enumerate() {
                 let ref_cell = get_reference_cell(*cell_type);
                 let ref_entities = (0..ref_cell.entity_count(dim0).unwrap())
@@ -279,7 +286,7 @@ impl Topology for SerialTopology {
 
                 let cstart = self.starts[i];
                 let cend = if i == self.starts.len() - 1 {
-                    self.connectivity[2][0].num_rows()
+                    self.connectivity[2][0].borrow().num_rows()
                 } else {
                     self.starts[i + 1]
                 };
@@ -288,27 +295,25 @@ impl Topology for SerialTopology {
                     for e in &ref_entities {
                         let vertices = e.iter().map(|x| cell[*x]).collect::<Vec<usize>>();
                         let mut found = false;
-                        for entity in data.iter_rows() {
+                        for entity in self.connectivity[dim0][0].borrow().iter_rows() {
                             if all_equal(entity, &vertices) {
                                 found = true;
                                 break;
                             }
                         }
                         if !found {
-                            data.add_row(&vertices);
+                            self.connectivity[dim0][0].borrow_mut().add_row(&vertices);
                         }
                     }
                 }
             }
-            self.connectivity[dim0][0] = data;
         } else {
             self.create_connectivity(dim0, 0);
             self.create_connectivity(dim1, 0);
             self.create_connectivity(self.dim(), dim0);
-            let mut data = AdjacencyList::<usize>::new();
-            let entities0 = &self.connectivity[dim0][0];
-            let entities1 = &self.connectivity[dim1][0];
-            let cell_to_entities0 = &self.connectivity[self.dim()][dim0];
+            let entities0 = &self.connectivity[dim0][0].borrow();
+            let entities1 = &self.connectivity[dim1][0].borrow();
+            let cell_to_entities0 = &self.connectivity[self.dim()][dim0].borrow();
 
             let mut cell_types = vec![ReferenceCellType::Point; entities0.num_rows()];
             for (i, cell_type) in self.cell_types.iter().enumerate() {
@@ -317,7 +322,7 @@ impl Topology for SerialTopology {
 
                 let cstart = self.starts[i];
                 let cend = if i == self.starts.len() - 1 {
-                    self.connectivity[2][0].num_rows()
+                    self.connectivity[2][0].borrow().num_rows()
                 } else {
                     self.starts[i + 1]
                 };
@@ -344,15 +349,14 @@ impl Topology for SerialTopology {
                         }
                     }
                 }
-                data.add_row(&row);
+                self.connectivity[dim0][dim1].borrow_mut().add_row(&row);
             }
-            self.connectivity[dim0][dim1] = data;
         }
     }
 
-    fn connectivity(&mut self, dim0: usize, dim1: usize) -> &AdjacencyList<usize> {
+    fn connectivity(&self, dim0: usize, dim1: usize) -> Ref<AdjacencyList<usize>> {
         self.create_connectivity(dim0, dim1);
-        &self.connectivity[dim0][dim1]
+        self.connectivity[dim0][dim1].borrow()
     }
 }
 
@@ -383,10 +387,6 @@ impl Grid for SerialGrid {
         &self.topology
     }
 
-    fn topology_mut(&mut self) -> &mut Self::Topology {
-        &mut self.topology
-    }
-
     fn geometry(&self) -> &Self::Geometry {
         &self.geometry
     }
@@ -398,108 +398,108 @@ mod test {
 
     #[test]
     fn test_connectivity() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0], (4, 2)),
             AdjacencyList::from_data(vec![0, 1, 2, 2, 1, 3], vec![0, 3, 6]),
             vec![ReferenceCellType::Triangle; 2],
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 2);
-        assert_eq!(g.topology_mut().entity_count(0), 4);
-        assert_eq!(g.topology_mut().entity_count(1), 5);
-        assert_eq!(g.topology_mut().entity_count(2), 2);
+        assert_eq!(g.topology().entity_count(0), 4);
+        assert_eq!(g.topology().entity_count(1), 5);
+        assert_eq!(g.topology().entity_count(2), 2);
         assert_eq!(g.geometry().point_count(), 4);
 
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(0).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(1).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(1).unwrap()[0], 1);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(2).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(2).unwrap()[0], 2);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(3).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 0).row(3).unwrap()[0], 3);
+        assert_eq!(g.topology().connectivity(0, 0).row(0).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 0).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 0).row(1).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 0).row(1).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(0, 0).row(2).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 0).row(2).unwrap()[0], 2);
+        assert_eq!(g.topology().connectivity(0, 0).row(3).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 0).row(3).unwrap()[0], 3);
 
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(0).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(0).unwrap()[0], 1);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(0).unwrap()[1], 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(1).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(1).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(1).unwrap()[1], 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(2).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(2).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(2).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(3).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(3).unwrap()[0], 1);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(3).unwrap()[1], 3);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(4).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(4).unwrap()[0], 2);
-        assert_eq!(g.topology_mut().connectivity(1, 0).row(4).unwrap()[1], 3);
+        assert_eq!(g.topology().connectivity(1, 0).row(0).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(0).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(1, 0).row(0).unwrap()[1], 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(1).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(1).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(1, 0).row(1).unwrap()[1], 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(2).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(2).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(1, 0).row(2).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(1, 0).row(3).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(3).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(1, 0).row(3).unwrap()[1], 3);
+        assert_eq!(g.topology().connectivity(1, 0).row(4).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(4).unwrap()[0], 2);
+        assert_eq!(g.topology().connectivity(1, 0).row(4).unwrap()[1], 3);
 
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(0).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(0).unwrap()[0], 1);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(0).unwrap()[1], 2);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(1).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(1).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(1).unwrap()[1], 2);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(1).unwrap()[2], 3);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(2).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(2).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(2).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(2).unwrap()[2], 4);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(3).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(3).unwrap()[0], 3);
-        assert_eq!(g.topology_mut().connectivity(0, 1).row(3).unwrap()[1], 4);
+        assert_eq!(g.topology().connectivity(0, 1).row(0).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(0, 1).row(0).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(0, 1).row(0).unwrap()[1], 2);
+        assert_eq!(g.topology().connectivity(0, 1).row(1).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(0, 1).row(1).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 1).row(1).unwrap()[1], 2);
+        assert_eq!(g.topology().connectivity(0, 1).row(1).unwrap()[2], 3);
+        assert_eq!(g.topology().connectivity(0, 1).row(2).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(0, 1).row(2).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 1).row(2).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(0, 1).row(2).unwrap()[2], 4);
+        assert_eq!(g.topology().connectivity(0, 1).row(3).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(0, 1).row(3).unwrap()[0], 3);
+        assert_eq!(g.topology().connectivity(0, 1).row(3).unwrap()[1], 4);
 
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(0).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(0).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(0).unwrap()[2], 2);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(1).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(1).unwrap()[0], 2);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(1).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(2, 0).row(1).unwrap()[2], 3);
+        assert_eq!(g.topology().connectivity(2, 0).row(0).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(2, 0).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(2, 0).row(0).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(2, 0).row(0).unwrap()[2], 2);
+        assert_eq!(g.topology().connectivity(2, 0).row(1).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(2, 0).row(1).unwrap()[0], 2);
+        assert_eq!(g.topology().connectivity(2, 0).row(1).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(2, 0).row(1).unwrap()[2], 3);
 
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(0).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(1).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(1).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(1).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(2).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(2).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(2).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(3).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(0, 2).row(3).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(0, 2).row(0).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 2).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 2).row(1).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(0, 2).row(1).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 2).row(1).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(0, 2).row(2).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(0, 2).row(2).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(0, 2).row(2).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(0, 2).row(3).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(0, 2).row(3).unwrap()[0], 1);
 
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(0).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(0).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(0).unwrap()[2], 2);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(1).unwrap().len(), 3);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(1).unwrap()[0], 3);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(1).unwrap()[1], 4);
-        assert_eq!(g.topology_mut().connectivity(2, 1).row(1).unwrap()[2], 0);
+        assert_eq!(g.topology().connectivity(2, 1).row(0).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(2, 1).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(2, 1).row(0).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(2, 1).row(0).unwrap()[2], 2);
+        assert_eq!(g.topology().connectivity(2, 1).row(1).unwrap().len(), 3);
+        assert_eq!(g.topology().connectivity(2, 1).row(1).unwrap()[0], 3);
+        assert_eq!(g.topology().connectivity(2, 1).row(1).unwrap()[1], 4);
+        assert_eq!(g.topology().connectivity(2, 1).row(1).unwrap()[2], 0);
 
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(0).unwrap().len(), 2);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(0).unwrap()[1], 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(1).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(1).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(2).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(2).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(3).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(3).unwrap()[0], 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(4).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(1, 2).row(4).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(0).unwrap().len(), 2);
+        assert_eq!(g.topology().connectivity(1, 2).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(1, 2).row(0).unwrap()[1], 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(1).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(1).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(1, 2).row(2).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(2).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(1, 2).row(3).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(3).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(4).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(1, 2).row(4).unwrap()[0], 1);
 
-        assert_eq!(g.topology_mut().connectivity(2, 2).row(0).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(2, 2).row(0).unwrap()[0], 0);
-        assert_eq!(g.topology_mut().connectivity(2, 2).row(1).unwrap().len(), 1);
-        assert_eq!(g.topology_mut().connectivity(2, 2).row(1).unwrap()[0], 1);
+        assert_eq!(g.topology().connectivity(2, 2).row(0).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(2, 2).row(0).unwrap()[0], 0);
+        assert_eq!(g.topology().connectivity(2, 2).row(1).unwrap().len(), 1);
+        assert_eq!(g.topology().connectivity(2, 2).row(1).unwrap()[0], 1);
     }
 
     #[test]
     fn test_serial_triangle_grid_octahedron() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0, 0.0,
@@ -517,15 +517,15 @@ mod test {
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 3);
-        assert_eq!(g.topology_mut().entity_count(0), 6);
-        assert_eq!(g.topology_mut().entity_count(1), 12);
-        assert_eq!(g.topology_mut().entity_count(2), 8);
+        assert_eq!(g.topology().entity_count(0), 6);
+        assert_eq!(g.topology().entity_count(1), 12);
+        assert_eq!(g.topology().entity_count(2), 8);
         assert_eq!(g.geometry().point_count(), 6);
     }
 
     #[test]
     fn test_serial_triangle_grid_screen() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 0.5, 0.0, 1.0, 0.5, 1.0,
@@ -543,15 +543,15 @@ mod test {
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 2);
-        assert_eq!(g.topology_mut().entity_count(0), 9);
-        assert_eq!(g.topology_mut().entity_count(1), 16);
-        assert_eq!(g.topology_mut().entity_count(2), 8);
+        assert_eq!(g.topology().entity_count(0), 9);
+        assert_eq!(g.topology().entity_count(1), 16);
+        assert_eq!(g.topology().entity_count(2), 8);
         assert_eq!(g.geometry().point_count(), 9);
     }
 
     #[test]
     fn test_serial_mixed_grid_screen() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 0.5, 0.0, 1.0, 0.5, 1.0,
@@ -574,16 +574,16 @@ mod test {
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 2);
-        assert_eq!(g.topology_mut().entity_count(0), 9);
-        assert_eq!(g.topology_mut().entity_count(1), 14);
-        assert_eq!(g.topology_mut().entity_count(2), 6);
+        assert_eq!(g.topology().entity_count(0), 9);
+        assert_eq!(g.topology().entity_count(1), 14);
+        assert_eq!(g.topology().entity_count(2), 6);
         assert_eq!(g.geometry().point_count(), 9);
     }
 
     #[test]
     fn test_higher_order_grid() {
         let s = 1.0 / (2.0 as f64).sqrt();
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 1.0, 0.0, s, s, 0.0, 1.0, -s, s, -1.0, 0.0, -s, -s, 0.0, -1.0, s, -s,
@@ -595,15 +595,15 @@ mod test {
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 2);
-        assert_eq!(g.topology_mut().entity_count(0), 4);
-        assert_eq!(g.topology_mut().entity_count(1), 5);
-        assert_eq!(g.topology_mut().entity_count(2), 2);
+        assert_eq!(g.topology().entity_count(0), 4);
+        assert_eq!(g.topology().entity_count(1), 5);
+        assert_eq!(g.topology().entity_count(2), 2);
         assert_eq!(g.geometry().point_count(), 9);
     }
 
     #[test]
     fn test_higher_order_mixed_grid() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 1.5, 0.25, 0.0, 0.0, 0.5, 0.5,
@@ -624,9 +624,9 @@ mod test {
         );
         assert_eq!(g.topology().dim(), 2);
         assert_eq!(g.geometry().dim(), 3);
-        assert_eq!(g.topology_mut().entity_count(0), 6);
-        assert_eq!(g.topology_mut().entity_count(1), 8);
-        assert_eq!(g.topology_mut().entity_count(2), 3);
+        assert_eq!(g.topology().entity_count(0), 6);
+        assert_eq!(g.topology().entity_count(1), 8);
+        assert_eq!(g.topology().entity_count(2), 3);
         assert_eq!(g.geometry().point_count(), 13);
     }
 }

--- a/grid/src/io.rs
+++ b/grid/src/io.rs
@@ -57,7 +57,7 @@ fn get_gmsh_cell(cell_type: ReferenceCellType, degree: usize) -> usize {
 }
 
 /// Export a grid as a gmsh file
-pub fn export_as_gmsh(grid: &mut SerialGrid, fname: String) {
+pub fn export_as_gmsh(grid: &SerialGrid, fname: String) {
     let mut gmsh_s = String::from("");
     gmsh_s.push_str("$MeshFormat\n");
     gmsh_s.push_str("4.1 0 8\n");
@@ -86,7 +86,7 @@ pub fn export_as_gmsh(grid: &mut SerialGrid, fname: String) {
     gmsh_s.push_str("$Elements\n");
 
     let tdim = grid.topology().dim();
-    let cell_count = grid.topology_mut().entity_count(tdim);
+    let cell_count = grid.topology().entity_count(tdim);
     let ncoordelements = grid.geometry().coordinate_elements().len();
     gmsh_s.push_str(&format!("{ncoordelements} {cell_count} 1 {cell_count}\n"));
     for (i, element) in grid.geometry().coordinate_elements().iter().enumerate() {
@@ -128,13 +128,13 @@ mod test {
 
     #[test]
     fn test_gmsh_output_regular_sphere() {
-        let mut g = regular_sphere(2);
-        export_as_gmsh(&mut g, String::from("_test_io_sphere.msh"));
+        let g = regular_sphere(2);
+        export_as_gmsh(&g, String::from("_test_io_sphere.msh"));
     }
 
     #[test]
     fn test_gmsh_output_quads() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 0.5, 0.0, 1.0, 0.5, 1.0,
@@ -148,12 +148,12 @@ mod test {
             ),
             vec![ReferenceCellType::Quadrilateral; 4],
         );
-        export_as_gmsh(&mut g, String::from("_test_io_screen.msh"));
+        export_as_gmsh(&g, String::from("_test_io_screen.msh"));
     }
 
     #[test]
     fn test_gmsh_output_mixed_cell_type() {
-        let mut g = SerialGrid::new(
+        let g = SerialGrid::new(
             Array2D::from_data(
                 vec![
                     0.0, 0.0, 0.5, 0.0, 1.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 0.5, 0.0, 1.0, 0.5, 1.0,
@@ -174,6 +174,6 @@ mod test {
                 ReferenceCellType::Quadrilateral,
             ],
         );
-        export_as_gmsh(&mut g, String::from("_test_io_screen_mixed.msh"));
+        export_as_gmsh(&g, String::from("_test_io_screen_mixed.msh"));
     }
 }

--- a/grid/src/shapes.rs
+++ b/grid/src/shapes.rs
@@ -30,16 +30,16 @@ pub fn regular_sphere(refinement_level: usize) -> SerialGrid {
     );
     let ref_e = Triangle {};
     for _level in 0..refinement_level {
-        let nvertices_old = g.topology_mut().entity_count(0);
-        let ncells_old = g.topology_mut().entity_count(2);
-        let nvertices = g.topology_mut().entity_count(0) + g.topology_mut().entity_count(1);
+        let nvertices_old = g.topology().entity_count(0);
+        let ncells_old = g.topology().entity_count(2);
+        let nvertices = g.topology().entity_count(0) + g.topology().entity_count(1);
         let mut coordinates = Array2D::<f64>::new((nvertices, 3));
         let mut cells = AdjacencyList::<usize>::new();
 
         for i in 0..ncells_old {
             let ti = g.topology().index_map()[i];
             let tedges = (0..3)
-                .map(|x| unsafe { g.topology_mut().connectivity(2, 1).row_unchecked(ti)[x] })
+                .map(|x| unsafe { g.topology().connectivity(2, 1).row_unchecked(ti)[x] })
                 .collect::<Vec<usize>>();
             let gi = g.geometry().index_map()[i];
             let tv = g.topology().cell(ti).unwrap();

--- a/traits/src/grid.rs
+++ b/traits/src/grid.rs
@@ -2,6 +2,7 @@
 
 use crate::cell::ReferenceCellType;
 use solvers_tools::arrays::AdjacencyList;
+use std::cell::Ref;
 
 pub trait Geometry {
     //! Grid geometry
@@ -39,10 +40,10 @@ pub trait Topology {
     fn index_map(&self) -> &[usize];
 
     /// The number of entities of dimension `dim`
-    fn entity_count(&mut self, dim: usize) -> usize;
+    fn entity_count(&self, dim: usize) -> usize;
 
     /// The indices of the vertices that from cell with index `index`
-    fn cell(&self, index: usize) -> Option<&[usize]>;
+    fn cell(&self, index: usize) -> Option<Ref<[usize]>>;
 
     /// The indices of the vertices that from cell with index `index`
     fn cell_type(&self, index: usize) -> Option<ReferenceCellType>;
@@ -50,10 +51,10 @@ pub trait Topology {
     /// Create the connectivity of entities of dimension `dim0` to entities of dimension `dim1`
     ///
     /// If this function is called multiple times, it will do nothing after the first call
-    fn create_connectivity(&mut self, dim0: usize, dim1: usize);
+    fn create_connectivity(&self, dim0: usize, dim1: usize);
 
     /// Create the connectivity information for all dimensions
-    fn create_connectivity_all(&mut self) {
+    fn create_connectivity_all(&self) {
         for dim0 in 0..self.dim() {
             for dim1 in 0..self.dim() {
                 self.create_connectivity(dim0, dim1);
@@ -62,7 +63,7 @@ pub trait Topology {
     }
 
     /// Get the connectivity of entities of dimension `dim0` to entities of dimension `dim1`
-    fn connectivity(&mut self, dim0: usize, dim1: usize) -> &AdjacencyList<usize>;
+    fn connectivity(&self, dim0: usize, dim1: usize) -> Ref<AdjacencyList<usize>>;
 }
 
 pub trait Grid {
@@ -76,9 +77,6 @@ pub trait Grid {
 
     /// Get the grid topology (See [Topology])
     fn topology(&self) -> &Self::Topology;
-
-    /// Get a mutable version of the grid topology (See [Topology])
-    fn topology_mut(&mut self) -> &mut Self::Topology;
 
     /// Get the grid geometry (See [Geometry])
     fn geometry(&self) -> &Self::Geometry;


### PR DESCRIPTION
This allows grids to me non-mutable and removes the calling of `topology_mut` everywhere.

This may need replacing by a RWLock in parallel (or it might not, as each process only needs to change the data relevant to the entities it owns